### PR TITLE
Only set fringe-bitmap when available

### DIFF
--- a/vi-tilde-fringe.el
+++ b/vi-tilde-fringe.el
@@ -79,11 +79,12 @@ empty."
   :group 'emulations
   (if vi-tilde-fringe-mode
       (progn
-        (define-fringe-bitmap 'vi-tilde-fringe-bitmap
-          vi-tilde-fringe-bitmap-array nil nil 'center)
-        (setq indicate-empty-lines t)
-        (add-to-list 'fringe-indicator-alist
-                     '(empty-line . vi-tilde-fringe-bitmap)))
+        (when (fboundp 'define-fringe-bitmap)
+          (define-fringe-bitmap 'vi-tilde-fringe-bitmap
+            vi-tilde-fringe-bitmap-array nil nil 'center)
+          (setq indicate-empty-lines t)
+          (add-to-list 'fringe-indicator-alist
+                       '(empty-line . vi-tilde-fringe-bitmap))))
     (setq indicate-empty-lines nil)))
 
 ;;;###autoload


### PR DESCRIPTION
If emacs is compiled with --without-x then the method define-fringe-bitmap is not defined. Flycheck (see https://github.com/flycheck/flycheck/blob/0.25.1/flycheck.el#L3186) and spacemacs (see https://github.com/syl20bnr/spacemacs/blob/v0.105.14/layers/syntax-checking/packages.el#L36) handle this in a similar fashion (flycheck issue #57 is related)
